### PR TITLE
Updated dead doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sample React app for KaiOS
 
-Simple example of a to-do list, for more information see [KaiOS Developer Portal](https://developer.kaiostech.com/getting-started/build-your-first-app/sample-code#react)
+Simple example of a to-do list, for more information see [KaiOS Developer Portal](https://developer.kaiostech.com/docs/02.getting-started/03.build-your-first-package-app/sample-code#react)
 
 ![](./docs/to-do-on-input.png)
 ![](./docs/to-do.png)
@@ -31,5 +31,5 @@ yarn build
 
 ## Send the app to a KaiOS device
 
-follow [os-env-setup](https://developer.kaiostech.com/getting-started/env-setup/os-env-setup) and [test-your-apps](https://developer.kaiostech.com/getting-started/build-your-first-package-app/test-your-apps)
+follow [os-env-setup](https://developer.kaiostech.com/docs/02.getting-started/01.env-setup/os-env-setup) and [test-your-apps](https://developer.kaiostech.com/docs/02.getting-started/03.build-your-first-package-app/test-your-apps)
 install to your device.


### PR DESCRIPTION
# Links updated

Links used in `README.md` updated to reflect recent changes in `https://developer.kaiostech.com/` 

**KaiOS Developer Portal** link changed to https://developer.kaiostech.com/docs/02.getting-started/03.build-your-first-package-app/sample-code#react

**os-env-setup** link changed to https://developer.kaiostech.com/docs/02.getting-started/01.env-setup/os-env-setup
**test-your-apps** link changed to https://developer.kaiostech.com/docs/02.getting-started/03.build-your-first-package-app/test-your-apps

# Result
All links in `README.md` is working instead of showing the following page

<img width="977" alt="Screenshot 2021-04-15 at 12 26 36 PM" src="https://user-images.githubusercontent.com/76202617/114827104-e7fb2680-9de5-11eb-99d5-5e3bb7b05b4d.png">



